### PR TITLE
Fix deprecation notice in Rails 5

### DIFF
--- a/lib/transaction_isolation/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/postgresql_adapter.rb
@@ -54,7 +54,7 @@ if defined?( ActiveRecord::ConnectionAdapters::PostgreSQLAdapter )
 
           def translate_exception_with_transaction_isolation_conflict( exception, message )
             if isolation_conflict?( exception )
-              ::ActiveRecord::TransactionIsolationConflict.new( "Transaction isolation conflict detected: #{exception.message}", exception )
+              ::ActiveRecord::TransactionIsolationConflict.new( "Transaction isolation conflict detected: #{exception.message}" )
             else
               translate_exception_without_transaction_isolation_conflict( exception, message )
             end


### PR DESCRIPTION
Rails 5 doesn't like the original_exception argument to `ActiveRecord::TransactionIsolationConflict` anymore.