### PR TITLE
Fixes ActiveRecord 3 support.

### DIFF
--- a/lib/transaction_isolation/active_record/errors.rb
+++ b/lib/transaction_isolation/active_record/errors.rb
@@ -6,5 +6,11 @@ module ActiveRecord
   # Serialization conflicts happen when db engine is using multi-version concurrency control.
   # Often db engines combine both approaches and thus generate both types of errors.
 
-  class TransactionIsolationConflict < ::ActiveRecord::WrappedDatabaseException; end
+  class TransactionIsolationConflict < ::ActiveRecord::WrappedDatabaseException
+    if ActiveSupport::VERSION::MAJOR == 3
+      def initialize message, original_exception = nil
+        super(message, original_exception)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently ActiveSuport 3 is broken due to the usage of the arity 1 intializer for TransactionIsolationConflict.

This PR fixes restores support by creating an arity 1..2 initializer only when ActiveSupport 3 is present.

I understand that ActiveSupport 3 is not supported by its maintainers any longer, but the transaction_isolation project's gemspec states it's supported, and it's still used somewhat frequently.