### PR TITLE
Adapted to work in Mysql 8 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 NO LONGER MAINTAINED - PLEASE FORK OR SEEK OTHER SOLUTIONS
 
+This is a fork from [qertoip](https://github.com/qertoip/transaction_isolation), I just needed to support MySQL 8
 
 # transaction_isolation
 

--- a/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
@@ -30,7 +30,7 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
               'SERIALIZABLE' => :serializable
           }
           
-          VERSION = execute("SELECT VERSION()")[0].to_i
+          @@version = nil
           
           VERSION_ISOL_LEVEL = -> (version) { version >= 8 ? "transaction_isolation" : "tx_isolation" }
           
@@ -39,7 +39,8 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
           end
           
           def current_vendor_isolation_level
-            select_value( "SELECT @@session.#{VERSION_ISOL_LEVEL[VERSION]}" ).gsub( '-', ' ' )
+            @@version ||= execute("SELECT VERSION()")[0].to_i
+            select_value( "SELECT @@session.#{VERSION_ISOL_LEVEL[@@version]}" ).gsub( '-', ' ' )
           end
           
           def isolation_level( level )

--- a/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
@@ -30,12 +30,16 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
               'SERIALIZABLE' => :serializable
           }
           
+          VERSION = execute("SELECT VERSION()")[0].to_i
+          
+          VERSION_ISOL_LEVEL = -> (version) { version >= 8 ? "transaction_isolation" : "tx_isolation" }
+          
           def current_isolation_level
             ANSI_ISOLATION_LEVEL[current_vendor_isolation_level]
           end
           
           def current_vendor_isolation_level
-            select_value( "SELECT @@session.tx_isolation" ).gsub( '-', ' ' )
+            select_value( "SELECT @@session.#{VERSION_ISOL_LEVEL[VERSION]}" ).gsub( '-', ' ' )
           end
           
           def isolation_level( level )

--- a/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
@@ -39,7 +39,7 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
           end
           
           def current_vendor_isolation_level
-            @@version ||= execute("SELECT VERSION()")[0].to_i
+            @@version ||= execute("SELECT VERSION()").first.[0].to_i
             select_value( "SELECT @@session.#{VERSION_ISOL_LEVEL[@@version]}" ).gsub( '-', ' ' )
           end
           

--- a/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
@@ -39,7 +39,7 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
           end
           
           def current_vendor_isolation_level
-            @@version ||= execute("SELECT VERSION()").first.[0].to_i
+            @@version ||= execute("SELECT VERSION()").first[0].to_i
             select_value( "SELECT @@session.#{VERSION_ISOL_LEVEL[@@version]}" ).gsub( '-', ' ' )
           end
           


### PR DESCRIPTION
Added version to decide how to get the current isolation level. In MySQL <= 5.7 is `tx_isolation`, in MySQL 8 is `transaction_isolation`